### PR TITLE
fix build code error in test environment

### DIFF
--- a/src/Decoder.js
+++ b/src/Decoder.js
@@ -9,7 +9,7 @@ class Decoder {
     const valid = multibase.isEncoded(base58)
     if (!valid)
       throw new Error('Base58 string is invalid. Cannot construct Decoder.')
-    
+
     this.base58 = base58
   }
 
@@ -29,10 +29,10 @@ class Decoder {
         }
       }
 
-      if (value instanceof Buffer) {
+      if (value instanceof Buffer || value instanceof Uint8Array) {
         value = cbor.decode(value).toString('hex')
       }
-    
+
       acc[key] = value
       return acc
     }, {})


### PR DESCRIPTION
Fix related to this issue: https://github.com/hildjj/node-cbor/issues/139

To summarize, in blockcerts cert-verifier-js, I was getting an error with the build test with jest. I believe it has to do with something around jsdom and the way such global constructors are handled, but this fix is the one that allows the build to keep working in various environment: node, browser, jest.