### PR TITLE
Add the Goerli support in keymap

### DIFF
--- a/src/Keymap.js
+++ b/src/Keymap.js
@@ -23,7 +23,8 @@ const chain = {
     networks: {
       mainnet: 1,
       ropsten: 3,
-      rinkeby: 4
+      rinkeby: 4,
+      goerli: 5
     }
   },
   mtc: {


### PR DESCRIPTION
Hi maintainers,

This PR is to add the Goerli, which is an Ethereum testnet.
Could you review this?

### Background

I'm a [Blockcerts.org](https://www.blockcerts.org/) user and contributor.
Now, the Blockcerts module [cert-verifier-js](https://github.com/blockchain-certificates/cert-verifier-js) has been using this npm and support only the Ropsten in Ethereum testnets.

Ethereum announced that the Ropsten will be closed in Q4 2022.
So, We have planned at [this page](https://community.blockcerts.org/t/ethereum-announced-the-testnet-ropsten-would-be-closed-in-q4-2022/3227) to support recommended testnets Goerli and Sepolia.

### Refs

- [Goerli info](https://github.com/eth-clients/goerli)

>Network ID: 5
>Chain ID: 5

- #18