### PR TITLE
Add the Sepolia support in keymap

### DIFF
--- a/src/Keymap.js
+++ b/src/Keymap.js
@@ -24,7 +24,8 @@ const chain = {
       mainnet: 1,
       ropsten: 3,
       rinkeby: 4,
-      goerli: 5
+      goerli: 5,
+      sepolia: 11155111
     }
   },
   mtc: {

--- a/src/Keymap.js
+++ b/src/Keymap.js
@@ -23,7 +23,8 @@ const chain = {
     networks: {
       mainnet: 1,
       ropsten: 3,
-      rinkeby: 4
+      rinkeby: 4,
+      goerli: 5
     }
   },
   mtc: {


### PR DESCRIPTION
Hi maintainers,

This PR is to add the Sepolia, which is an Ethereum testnet.
Could you review this? I recommend you will check this after checking #17.

### Refs:

- [Sepolia info](https://github.com/eth-clients/sepolia)
>Network ID: 11155111
>Chain ID: 11155111
- #17