### PR TITLE
feature(networks): Add mock network support

### DIFF
--- a/src/Keymap.js
+++ b/src/Keymap.js
@@ -34,6 +34,12 @@ const chain = {
       mainnet: 137,
       mumbai: 80001
     }
+  },
+  mocknet: {
+    id: -1,
+    networks: {
+      mocknet: -1
+    }
   }
 }
 

--- a/src/__tests__/Decoder.test.js
+++ b/src/__tests__/Decoder.test.js
@@ -1,7 +1,9 @@
 const Decoder = require('../Decoder')
 const proofValue = require('./proofValue.json')
+const mocknetProofValue = require('./mocknetProofValue.json')
 
 const resultBase58 = 'z6nGv6rMRybRe9CuMzbQbdu7sA858v1d13JU3hoAr1x93cheinB35kDXqCvaA93WTLWGtLZMdQSvvNCxEMZPhLvDa4CbUYkm4pCwBe7kCZAsuwHZwHxgyzCbRUWFbMXHhkVSHoPYmPzfi4arfHKMgKSurZ7oqe3GHRdi78TbHGvA65edK8JBEdTUt8SpCdc7wz5qiwj3THtcNAXfgK4LmCAu4fq8CnjLcMtGoEdfXfjy3turtaTapyM3katuYKAzbJF3FiE8i8NXBsiBnEbvKk7k'
+const mocknetResultBase58 = 'zYaPdLQCuei4vhe5Bdz4GjXD4iYkEZL1x2jgNjJArVBt29RUn14RZspAqFo2XDwKtTdBCRZtzxpTLwGhJxKv7TGeQQpBbgLgtM6vF15cBc4TBwd3sJc2ZxEjve6Ncuu1XMwczshC8injjzUpjLhhwKTijnUSdoxwj5jyv9CztRmkDajRZAQmaqgXuCG8BtoLqsbCubwbpbvEHPJrKjqHrt99C6zPx5X89C8eNMFFr5d7GSSWBbAHrwoCbjYvepm'
 
 describe('Decoder', () => {
   test('should create instance from valid props', () => {
@@ -24,5 +26,12 @@ describe('Decoder', () => {
     const result = decoder.decode()
     
     expect(result).toEqual(proofValue)
+  })
+
+  test('should decode a mock proofValue', () => {
+    const decoder = new Decoder(mocknetResultBase58)
+    const result = decoder.decode()
+
+    expect(result).toEqual(mocknetProofValue)
   })
 })

--- a/src/__tests__/Encoder.test.js
+++ b/src/__tests__/Encoder.test.js
@@ -1,7 +1,9 @@
 const Encoder = require('../Encoder')
 const proofValue = require('./proofValue.json')
+const mocknetProofValue = require('./mocknetProofValue.json')
 
 const resultBase58 = 'z6nGv6rMRybRe9CuMzbQbdu7sA858v1d13JU3hoAr1x93cheinB35kDXqCvaA93WTLWGtLZMdQSvvNCxEMZPhLvDa4CbUYkm4pCwBe7kCZAsuwHZwHxgyzCbRUWFbMXHhkVSHoPYmPzfi4arfHKMgKSurZ7oqe3GHRdi78TbHGvA65edK8JBEdTUt8SpCdc7wz5qiwj3THtcNAXfgK4LmCAu4fq8CnjLcMtGoEdfXfjy3turtaTapyM3katuYKAzbJF3FiE8i8NXBsiBnEbvKk7k'
+const mocknetResultBase58 = 'zYaPdLQCuei4vhe5Bdz4GjXD4iYkEZL1x2jgNjJArVBt29RUn14RZspAqFo2XDwKtTdBCRZtzxpTLwGhJxKv7TGeQQpBbgLgtM6vF15cBc4TBwd3sJc2ZxEjve6Ncuu1XMwczshC8injjzUpjLhhwKTijnUSdoxwj5jyv9CztRmkDajRZAQmaqgXuCG8BtoLqsbCubwbpbvEHPJrKjqHrt99C6zPx5X89C8eNMFFr5d7GSSWBbAHrwoCbjYvepm'
 
 describe('Encoder', () => {
   test('should create instance from valid props', () => {
@@ -24,5 +26,12 @@ describe('Encoder', () => {
     const result = encoder.encode()
 
     expect(result.toString()).toEqual(resultBase58)
+  })
+
+  test('should encode a mock proofValue', () => {
+    const encoder = new Encoder(mocknetProofValue)
+    const result = encoder.encode()
+
+    expect(result.toString()).toEqual(mocknetResultBase58)
   })
 })

--- a/src/__tests__/mocknetProofValue.json
+++ b/src/__tests__/mocknetProofValue.json
@@ -1,0 +1,11 @@
+{
+  "path": [
+    { "right": "51b4e22ed024ec7f38dc68b0bf78c87eda525ab0896b75d2064bdb9fc60b2698" },
+    { "right": "61c56cca660b2e616d0bd62775e728f50275ae44adf12d1bfb9b9c507a14766b" }
+  ],
+  "merkleRoot": "3c9ee831b8705f2fbe09f8b3a92247eed88cdc90418c024924be668fdc92e781", 
+  "targetHash": "c65c6184e3d5a945ddb5437e93ea312411fd33aa1def22b0746d6ecd4aa30f20",
+  "anchors": [
+    "blink:mocknet:mocknet:d41d8cd98f00b204e9800998ecf8427e"
+  ]
+}

--- a/src/__tests__/proofValue.json
+++ b/src/__tests__/proofValue.json
@@ -6,6 +6,6 @@
   "merkleRoot": "3c9ee831b8705f2fbe09f8b3a92247eed88cdc90418c024924be668fdc92e781", 
   "targetHash": "c65c6184e3d5a945ddb5437e93ea312411fd33aa1def22b0746d6ecd4aa30f20",
   "anchors": [
-    "blink:mtc:mumbai:582733d7cef8035d87cecc9ebbe13b3a2f6cc52583fbcd2b9709f20a6b8b56b3"
+    "blink:btc:testnet:582733d7cef8035d87cecc9ebbe13b3a2f6cc52583fbcd2b9709f20a6b8b56b3"
   ]
 }


### PR DESCRIPTION
Add Keymap entry which allows for encoding / decoding test network MerkleProof2019 without touching a real blockchain.

Added tests for mock values as well.

Target encoded blink looks like `blink:mocknet:mocknet:...`